### PR TITLE
5 potential crash with a vma lma different address in the binary elf

### DIFF
--- a/jiffi2.txt
+++ b/jiffi2.txt
@@ -11,6 +11,9 @@ Supported formats of the Atari Jaguar.
 - ROM
 
 
+Version 1.0.3 - 08-20-2024
+- Fix potential crash with a VMA & LMA different address in the binary ELF
+
 Version 1.0.2 - 06-23-2024
 - Added a Visual Studio 2022 project
 - Removed hardcoded libraries version in the about's UI

--- a/src/version.h
+++ b/src/version.h
@@ -5,6 +5,6 @@
 // Release Information
 #define MAJOR   1		// Major version number
 #define MINOR   0		// Minor version number
-#define PATCH   2		// Patch release number
+#define PATCH   3		// Patch release number
 
 #endif // __VERSION_H__

--- a/vs2022/JiFFI2.vcxproj
+++ b/vs2022/JiFFI2.vcxproj
@@ -60,7 +60,7 @@
       <ObjectFileName>$(IntDir)obj\</ObjectFileName>
       <CompileAsManaged>false</CompileAsManaged>
       <OmitDefaultLibName>false</OmitDefaultLibName>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(Qt_LIBPATH_);%(AdditionalLibraryDirectories);C:\SDK\ELF\libelf-0.8.13\lib;C:\SDK\crc\crc32\lib;C:\SDK\XML\tinyxml2-10.0.0\lib</AdditionalLibraryDirectories>


### PR DESCRIPTION
Fix potential crash with a VMA & LMA different address in the binary ELF.